### PR TITLE
fix: escape <& characters in attribute values

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
 const path = require('path');
 
 function escapeAttribute(s = '') {
-  return s.replace(/</g, '&lt;')
-          .replace(/&/g, '&amp;')
+  return s.replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
           .replace(/"/g, '&quot;')
           .replace(/\n/g, '');
 }
 
 function escapeContent(s = '') {
-  return s.replace(/</g, '&lt;').replace(/&/g, '&amp;');
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;');
 }
 
 function treeToXML(tree) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@
 const path = require('path');
 
 function escapeAttribute(s = '') {
-  return s.replace(/"/g, '&quot;').replace(/\n/g, '');
+  return s.replace(/</g, '&lt;')
+          .replace(/&/g, '&amp;')
+          .replace(/"/g, '&quot;')
+          .replace(/\n/g, '');
 }
 
 function escapeContent(s = '') {


### PR DESCRIPTION
If you use static initializers in JS you will get an attribute in cobertura's output xml like this: 

```
<method name="<static_initializer>" hits="1" signature="()V">
	<lines >
		<line number="2" hits="1"/>
	</lines>
</method>
```

This is malformed xml as "<" (or "&") are not allowed in an attribute name according to the spec and a validator will output: 

```
error on line 13 at column 20: Unescaped '<' not allowed in attributes values
```

Gitlab will not be able to parse the xml and will not display the coverage. I have fixed this by escaping & and < for attributes, as it is in content. 

I also changed the ordering as escaping & later in the chain will result in an output like: `&amp;lt;` instead of `&lt;`.
