### PR TITLE
Fixing some things

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ function treeToXML(tree) {
     .join(' ');
 
   if (!children.length) {
-    return `${indent}<${tag} ${attrsString}/>\n`;
+    return `${indent}<${tag}${attrsString && ` ${attrsString}`}/>\n`;
   }
 
   const childrenString = children.map(treeToXML).join('');
 
-  return `${indent}<${tag} ${attrsString}>\n${childrenString}${indent}</${tag}>\n`;
+  return `${indent}<${tag}${attrsString && ` ${attrsString}`}>\n${childrenString}${indent}</${tag}>\n`;
 }
 
 module.exports = async function* coberturaReporter(source) {

--- a/index.js
+++ b/index.js
@@ -129,64 +129,70 @@ module.exports = async function* coberturaReporter(source) {
               ).toFixed(4),
             },
             nesting: 1,
-            children: value.children.map(c => ({
-              tag: 'class',
-              attrs: {
-                name: c.className,
-                filename: c.filename,
-                'line-rate': c.classLineRate,
-                'branch-rate': c.classBranchRate,
-              },
-              nesting: 2,
-              children: [
-                {
-                  tag: 'methods',
+            children: [
+              {
+                tag: 'classes',
+                nesting: 2,
+                children: value.children.map(c => ({
+                  tag: 'class',
+                  attrs: {
+                    name: c.className,
+                    filename: c.filename,
+                    'line-rate': c.classLineRate,
+                    'branch-rate': c.classBranchRate,
+                  },
                   nesting: 3,
-                  children: c.methods.map(m => ({
-                    tag: 'method',
-                    attrs: {
-                      name: m.name,
-                      hits: m.hits,
-                      signature: m.signature,
-                    },
-                    nesting: 4,
-                    children: [
-                      {
-                        tag: 'lines',
+                  children: [
+                    {
+                      tag: 'methods',
+                      nesting: 4,
+                      children: c.methods.map(m => ({
+                        tag: 'method',
+                        attrs: {
+                          name: m.name,
+                          hits: m.hits,
+                          signature: m.signature,
+                        },
                         nesting: 5,
                         children: [
                           {
-                            tag: 'line',
-                            attrs: {
-                              number: m.number,
-                              hits: m.hits,
-                            },
+                            tag: 'lines',
                             nesting: 6,
+                            children: [
+                              {
+                                tag: 'line',
+                                attrs: {
+                                  number: m.number,
+                                  hits: m.hits,
+                                },
+                                nesting: 7,
+                              },
+                            ],
                           },
                         ],
-                      },
-                    ],
-                  })),
-                },
-                {
-                  tag: 'lines',
-                  nesting: 3,
-                  children: c.lines.map(l => {
-                    const attrs = {
-                      number: l.number,
-                      hits: l.hits,
-                      branch: l.branch,
-                    };
+                      })),
+                    },
+                    {
+                      tag: 'lines',
+                      nesting: 4,
+                      children: c.lines.map(l => {
+                        const attrs = {
+                          number: l.number,
+                          hits: l.hits,
+                          branch: l.branch,
+                        };
 
-                    if (l.branch) {
-                      attrs['condition-coverage'] = l.conditionCoverage;
-                    }
+                        if (l.branch) {
+                          attrs['condition-coverage'] = l.conditionCoverage;
+                        }
 
-                    return { tag: 'line', nesting: 4, attrs };
-                  }),
-                },
-              ],
-            })),
+                        return { tag: 'line', nesting: 5, attrs };
+                      }),
+                    },
+                  ],
+                })),
+              },
+            ],
           })),
         };
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -190,42 +190,42 @@ test('single test', async () => {
     '<?xml version="1.0" ?>\n',
     '<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">\n',
     `<coverage lines-valid="44" lines-covered="42" line-rate="0.9545" branches-valid="13" branches-covered="12" branch-rate="0.9231" timestamp=${expectedTimestampValue} complexity="0" version="0.1">\n` +
-      '\t<sources >\n' +
-      '\t\t<source >\n' +
+      '\t<sources>\n' +
+      '\t\t<source>\n' +
       '/Users/bacebu4/dev/cobertura-test\n' +
       '\t\t</source>\n' +
       '\t</sources>\n' +
-      '\t<packages >\n' +
+      '\t<packages>\n' +
       '\t\t<package name="cobertura-test.src.bar.qux" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t<classes >\n' +
+      '\t\t\t<classes>\n' +
       '\t\t\t\t<class name="qux.js" filename="src/bar/qux/qux.js" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t<methods>\n' +
       '\t\t\t\t\t\t<method name="qux" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t\t\t<line number="1" hits="1"/>\n' +
       '\t\t\t\t\t\t\t</lines>\n' +
       '\t\t\t\t\t\t</method>\n' +
       '\t\t\t\t\t</methods>\n' +
-      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (2/2)"/>\n' +
       '\t\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
       '\t\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
       '\t\t\t\t\t</lines>\n' +
       '\t\t\t\t</class>\n' +
       '\t\t\t\t<class name="qux.test.js" filename="src/bar/qux/qux.test.js" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t<methods>\n' +
       '\t\t\t\t\t\t<method name="(anonymous_0)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t\t\t<line number="5" hits="1"/>\n' +
       '\t\t\t\t\t\t\t</lines>\n' +
       '\t\t\t\t\t\t</method>\n' +
       '\t\t\t\t\t\t<method name="(anonymous_1)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t\t\t<line number="6" hits="1"/>\n' +
       '\t\t\t\t\t\t\t</lines>\n' +
       '\t\t\t\t\t\t</method>\n' +
       '\t\t\t\t\t</methods>\n' +
-      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
       '\t\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
       '\t\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
@@ -242,16 +242,16 @@ test('single test', async () => {
       '\t\t\t</classes>\n' +
       '\t\t</package>\n' +
       '\t\t<package name="cobertura-test" line-rate="0.8462" branch-rate="0.7500">\n' +
-      '\t\t\t<classes >\n' +
+      '\t\t\t<classes>\n' +
       '\t\t\t\t<class name="foo.js" filename="foo.js" line-rate="0.8462" branch-rate="0.7500">\n' +
-      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t<methods>\n' +
       '\t\t\t\t\t\t<method name="foo" hits="2" signature="()V">\n' +
-      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t\t\t<line number="1" hits="2"/>\n' +
       '\t\t\t\t\t\t\t</lines>\n' +
       '\t\t\t\t\t\t</method>\n' +
       '\t\t\t\t\t</methods>\n' +
-      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (2/2)"/>\n' +
       '\t\t\t\t\t\t<line number="2" hits="2" branch="true" condition-coverage="0% (0/1)"/>\n' +
       '\t\t\t\t\t\t<line number="3" hits="0" branch="false"/>\n' +
@@ -270,26 +270,26 @@ test('single test', async () => {
       '\t\t\t</classes>\n' +
       '\t\t</package>\n' +
       '\t\t<package name="cobertura-test.src" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t<classes >\n' +
+      '\t\t\t<classes>\n' +
       '\t\t\t\t<class name="foo.test.js" filename="src/foo.test.js" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t<methods>\n' +
       '\t\t\t\t\t\t<method name="(anonymous_0)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t\t\t<line number="5" hits="1"/>\n' +
       '\t\t\t\t\t\t\t</lines>\n' +
       '\t\t\t\t\t\t</method>\n' +
       '\t\t\t\t\t\t<method name="(anonymous_1)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t\t\t<line number="6" hits="1"/>\n' +
       '\t\t\t\t\t\t\t</lines>\n' +
       '\t\t\t\t\t\t</method>\n' +
       '\t\t\t\t\t\t<method name="(anonymous_2)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t\t\t<line number="12" hits="1"/>\n' +
       '\t\t\t\t\t\t\t</lines>\n' +
       '\t\t\t\t\t\t</method>\n' +
       '\t\t\t\t\t</methods>\n' +
-      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t<lines>\n' +
       '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
       '\t\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
       '\t\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -197,113 +197,119 @@ test('single test', async () => {
       '\t</sources>\n' +
       '\t<packages >\n' +
       '\t\t<package name="cobertura-test.src.bar.qux" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t<class name="qux.js" filename="src/bar/qux/qux.js" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t\t<methods >\n' +
-      '\t\t\t\t\t<method name="qux" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t\t\t<line number="1" hits="1"/>\n' +
-      '\t\t\t\t\t\t</lines>\n' +
-      '\t\t\t\t\t</method>\n' +
-      '\t\t\t\t</methods>\n' +
-      '\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (2/2)"/>\n' +
-      '\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
-      '\t\t\t\t</lines>\n' +
-      '\t\t\t</class>\n' +
-      '\t\t\t<class name="qux.test.js" filename="src/bar/qux/qux.test.js" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t\t<methods >\n' +
-      '\t\t\t\t\t<method name="(anonymous_0)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t\t\t<line number="5" hits="1"/>\n' +
-      '\t\t\t\t\t\t</lines>\n' +
-      '\t\t\t\t\t</method>\n' +
-      '\t\t\t\t\t<method name="(anonymous_1)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t\t\t<line number="6" hits="1"/>\n' +
-      '\t\t\t\t\t\t</lines>\n' +
-      '\t\t\t\t\t</method>\n' +
-      '\t\t\t\t</methods>\n' +
-      '\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="4" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="5" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="6" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="7" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="8" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="9" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="10" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="11" hits="1" branch="false"/>\n' +
-      '\t\t\t\t</lines>\n' +
-      '\t\t\t</class>\n' +
+      '\t\t\t<classes >\n' +
+      '\t\t\t\t<class name="qux.js" filename="src/bar/qux/qux.js" line-rate="1.0000" branch-rate="1.0000">\n' +
+      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t\t<method name="qux" hits="1" signature="()V">\n' +
+      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t\t<line number="1" hits="1"/>\n' +
+      '\t\t\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t\t\t</method>\n' +
+      '\t\t\t\t\t</methods>\n' +
+      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (2/2)"/>\n' +
+      '\t\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t</class>\n' +
+      '\t\t\t\t<class name="qux.test.js" filename="src/bar/qux/qux.test.js" line-rate="1.0000" branch-rate="1.0000">\n' +
+      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t\t<method name="(anonymous_0)" hits="1" signature="()V">\n' +
+      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t\t<line number="5" hits="1"/>\n' +
+      '\t\t\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t\t\t</method>\n' +
+      '\t\t\t\t\t\t<method name="(anonymous_1)" hits="1" signature="()V">\n' +
+      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t\t<line number="6" hits="1"/>\n' +
+      '\t\t\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t\t\t</method>\n' +
+      '\t\t\t\t\t</methods>\n' +
+      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="4" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="5" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="6" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="7" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="8" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="9" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="10" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="11" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t</class>\n' +
+      '\t\t\t</classes>\n' +
       '\t\t</package>\n' +
       '\t\t<package name="cobertura-test" line-rate="0.8462" branch-rate="0.7500">\n' +
-      '\t\t\t<class name="foo.js" filename="foo.js" line-rate="0.8462" branch-rate="0.7500">\n' +
-      '\t\t\t\t<methods >\n' +
-      '\t\t\t\t\t<method name="foo" hits="2" signature="()V">\n' +
-      '\t\t\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t\t\t<line number="1" hits="2"/>\n' +
-      '\t\t\t\t\t\t</lines>\n' +
-      '\t\t\t\t\t</method>\n' +
-      '\t\t\t\t</methods>\n' +
-      '\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (2/2)"/>\n' +
-      '\t\t\t\t\t<line number="2" hits="2" branch="true" condition-coverage="0% (0/1)"/>\n' +
-      '\t\t\t\t\t<line number="3" hits="0" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="4" hits="0" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="5" hits="2" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="6" hits="2" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="7" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="8" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="9" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="10" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="11" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="12" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="13" hits="2" branch="false"/>\n' +
-      '\t\t\t\t</lines>\n' +
-      '\t\t\t</class>\n' +
+      '\t\t\t<classes >\n' +
+      '\t\t\t\t<class name="foo.js" filename="foo.js" line-rate="0.8462" branch-rate="0.7500">\n' +
+      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t\t<method name="foo" hits="2" signature="()V">\n' +
+      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t\t<line number="1" hits="2"/>\n' +
+      '\t\t\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t\t\t</method>\n' +
+      '\t\t\t\t\t</methods>\n' +
+      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (2/2)"/>\n' +
+      '\t\t\t\t\t\t<line number="2" hits="2" branch="true" condition-coverage="0% (0/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="3" hits="0" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="4" hits="0" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="5" hits="2" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="6" hits="2" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="7" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="8" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="9" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="10" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="11" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="12" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="13" hits="2" branch="false"/>\n' +
+      '\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t</class>\n' +
+      '\t\t\t</classes>\n' +
       '\t\t</package>\n' +
       '\t\t<package name="cobertura-test.src" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t<class name="foo.test.js" filename="src/foo.test.js" line-rate="1.0000" branch-rate="1.0000">\n' +
-      '\t\t\t\t<methods >\n' +
-      '\t\t\t\t\t<method name="(anonymous_0)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t\t\t<line number="5" hits="1"/>\n' +
-      '\t\t\t\t\t\t</lines>\n' +
-      '\t\t\t\t\t</method>\n' +
-      '\t\t\t\t\t<method name="(anonymous_1)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t\t\t<line number="6" hits="1"/>\n' +
-      '\t\t\t\t\t\t</lines>\n' +
-      '\t\t\t\t\t</method>\n' +
-      '\t\t\t\t\t<method name="(anonymous_2)" hits="1" signature="()V">\n' +
-      '\t\t\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t\t\t<line number="12" hits="1"/>\n' +
-      '\t\t\t\t\t\t</lines>\n' +
-      '\t\t\t\t\t</method>\n' +
-      '\t\t\t\t</methods>\n' +
-      '\t\t\t\t<lines >\n' +
-      '\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="4" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="5" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="6" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="7" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="8" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="9" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="10" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="11" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="12" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
-      '\t\t\t\t\t<line number="13" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="14" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="15" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="16" hits="1" branch="false"/>\n' +
-      '\t\t\t\t\t<line number="17" hits="1" branch="false"/>\n' +
-      '\t\t\t\t</lines>\n' +
-      '\t\t\t</class>\n' +
+      '\t\t\t<classes >\n' +
+      '\t\t\t\t<class name="foo.test.js" filename="src/foo.test.js" line-rate="1.0000" branch-rate="1.0000">\n' +
+      '\t\t\t\t\t<methods >\n' +
+      '\t\t\t\t\t\t<method name="(anonymous_0)" hits="1" signature="()V">\n' +
+      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t\t<line number="5" hits="1"/>\n' +
+      '\t\t\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t\t\t</method>\n' +
+      '\t\t\t\t\t\t<method name="(anonymous_1)" hits="1" signature="()V">\n' +
+      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t\t<line number="6" hits="1"/>\n' +
+      '\t\t\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t\t\t</method>\n' +
+      '\t\t\t\t\t\t<method name="(anonymous_2)" hits="1" signature="()V">\n' +
+      '\t\t\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t\t\t<line number="12" hits="1"/>\n' +
+      '\t\t\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t\t\t</method>\n' +
+      '\t\t\t\t\t</methods>\n' +
+      '\t\t\t\t\t<lines >\n' +
+      '\t\t\t\t\t\t<line number="1" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="2" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="3" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="4" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="5" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="6" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="7" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="8" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="9" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="10" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="11" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="12" hits="1" branch="true" condition-coverage="100% (1/1)"/>\n' +
+      '\t\t\t\t\t\t<line number="13" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="14" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="15" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="16" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t\t<line number="17" hits="1" branch="false"/>\n' +
+      '\t\t\t\t\t</lines>\n' +
+      '\t\t\t\t</class>\n' +
+      '\t\t\t</classes>\n' +
       '\t\t</package>\n' +
       '\t</packages>\n' +
       '</coverage>\n',


### PR DESCRIPTION
Currently, reports output like this:

```xml
<packages >
	<package ...>
		<class ...>
			<methods >
			</lines>
		</class>
		<class ...>
			<methods >
			</lines>
		</class>
	</package>
</packages>
```

They should look like this:

```xml
<packages>
	<package ...>
		<classes>
			<class ...>
				<methods>
				</lines>
			</class>
			<class ...>
				<methods>
				</lines>
			</class>
		</classes>
	</package>
</packages>
```

Differences:
- There should be a `<classes>` tag surrounding the `<class>` tags
- There shouldn't be a trailing space following tag names when there aren't any attributes

This PR fixes these things.